### PR TITLE
inherit source-doc description from string face

### DIFF
--- a/helm-go-package.el
+++ b/helm-go-package.el
@@ -50,7 +50,8 @@ It is `browse-url' by default."
 
 ;;; Faces
 (defface helm-source-go-package-godoc-description
-    '((t (:foreground "yellow")))
+  (let ((str (face-foreground 'font-lock-string-face)))
+    `((t (:foreground ,str))))
   "Face used for Godoc description."
   :group 'helm-go-package)
 


### PR DESCRIPTION
The yellow you selected is not visible with many light themes, e.g. Solarized-light. This patch makes helm-source-go-package-godoc-description colour inherit from font-lock-string-face, thus making it work with any color theme.
